### PR TITLE
Correção de palavra - arrays e slices

### DIFF
--- a/primeiros-passos-com-go/arrays-e-slices.md
+++ b/primeiros-passos-com-go/arrays-e-slices.md
@@ -201,7 +201,7 @@ func TestSoma(t *testing.T) {
 
 É importante questionar o valor dos seus testes. Ter o máximo de testes possível não deve ser o objetivo e sim ter o máximo de _confiança_ possível na sua base de código. Ter testes demais pode se tornar um problema real e só adiciona mais peso na manutenção. **Todo teste tem um custo**.
 
-No nosso caso, dá para perceber que ter dois testes para essa função é redundância. Se funciona para um soice de determindo tamanho, é muito provável que funciona para um slice de qualquer tamanho (dentro desse escopo).
+No nosso caso, dá para perceber que ter dois testes para essa função é redundância. Se funciona para um slice de determindo tamanho, é muito provável que funciona para um slice de qualquer tamanho (dentro desse escopo).
 
 A ferramenta de testes nativa do Go tem a funcionalidade de [cobertura de código](https://blog.golang.org/cover) que te ajuda a identificar áreas do seu código que você não cobriu. Já adianto que ter 100% de cobertura não deve ser seu objetivo; é apenas uma ferramenta para te dar uma ideia da sua cobertura. De qualquer forma, se você aplicar o TDD, é bem provável que chegue bem perto dos 100% de cobertura.
 


### PR DESCRIPTION
Correção da palavra soice para slice, no tópico sobre arrays e slices.