### PR TITLE
Igualando as assinaturas dos métodos

### DIFF
--- a/primeiros-passos-com-go/arrays-e-slices.md
+++ b/primeiros-passos-com-go/arrays-e-slices.md
@@ -305,16 +305,16 @@ Volte o teste da forma como estava e execute-o. Você deve ter a saída do teste
 O que precisamos fazer é percorrer as variáveis recebidas como argumento, calcular a soma com nossa função `Soma` de antes e adicioná-la ao slice que vamos retornar:
 
 ```go
-func SomaTudo(numerosParaSomar ...[]int) []int {
+func SomaTudo(numerosParaSomar ...[]int) (somas []int) {
     quantidadeDeNumeros := len(numerosParaSomar)
-    somas := make([]int, quantidadeDeNumeros)
+    somas = make([]int, quantidadeDeNumeros)
 
     for i, numeros := range numerosParaSomar {
         somas[i] = Soma(numeros)
     }
 
-    return somas
-}
+    return
+ }
 ```
 
 Muitas coisas novas para aprender!


### PR DESCRIPTION
Somente para manter os dois exemplos com a mesma assinatura.
Como a refatoração não passa pela assinatura do método, isso pode confundir.