### PR TITLE
Revisão em "Sync"

### DIFF
--- a/primeiros-passos-com-go/sync/sync.md
+++ b/primeiros-passos-com-go/sync/sync.md
@@ -123,7 +123,7 @@ Isso foi muito fácil, mas agora temos um requerimento que é: o programa precis
 ```go
 t.Run("roda concorrentemente em segurança", func(t *testing.T) {
 	contagemEsperada := 1000
-	contador := NovoContador()
+	contador := Contador{}
 
 	var wg sync.WaitGroup
 	wg.Add(contagemEsperada)


### PR DESCRIPTION
`NovoContador()` seria definido mais pra frente no capítulo, alterado para `Contador{}`.