### PR TITLE
Corrigida referência à variável

### DIFF
--- a/primeiros-passos-com-go/maps/maps.md
+++ b/primeiros-passos-com-go/maps/maps.md
@@ -20,7 +20,7 @@ import "testing"
 func TestBusca(t *testing.T) {
     dicionario := map[string]string{"teste": "isso é apenas um teste"}
 
-    resultado := Busca(dictionary, "teste")
+    resultado := Busca(dicionario, "teste")
     esperado := "isso é apenas um teste"
 
     if resultado != esperado {


### PR DESCRIPTION
A referência à variável dicionário não estava compatível com a tradução.