### PR TITLE
Correcao no codigo de exemplo na secao maps

### DIFF
--- a/primeiros-passos-com-go/maps/maps.md
+++ b/primeiros-passos-com-go/maps/maps.md
@@ -20,7 +20,7 @@ import "testing"
 func TestBusca(t *testing.T) {
     dicionario := map[string]string{"teste": "isso é apenas um teste"}
 
-    resultado := Busca(dictionary, "teste")
+    resultado := Busca(dicionario, "teste")
     esperado := "isso é apenas um teste"
 
     if resultado != esperado {


### PR DESCRIPTION
Na linha 8 o método `Busca` tentar usar a variável `dictionary`, quando na verdade creio que a intenção era utilizar a variável `dicionario`

Segue evidência:

<img width="776" alt="Screen Shot 2020-07-24 at 11 22 51" src="https://user-images.githubusercontent.com/34931766/88401420-1c363f00-cda0-11ea-8d43-9d76c31936f4.png">
