### PR TITLE
Seleção - nomes das variáveis diferentes

### DIFF
--- a/primeiros-passos-com-go/select/select.md
+++ b/primeiros-passos-com-go/select/select.md
@@ -21,7 +21,7 @@ func TestCorredor(t *testing.T) {
     URLRapida := "http://www.quii.co.uk"
 
     esperado := URLRapida
-    resultado := Corredor(URLLenta, urlRapida)
+    resultado := Corredor(URLLenta, URLRapida)
 
     if resultado != esperado {
         t.Errorf("resultado '%s', esperado '%s'", resultado, esperado)
@@ -281,7 +281,7 @@ func Corredor(a, b string) (vencedor string, erro error) {
 
 Alteramos a assinatura de `Corredor` para retornar o vencedor e um `erro`. Retornamos `nil` para nossos casos de sucesso.
 
-O compilador vai reclamar sobre seu _primeiro teste_ esperar apenas um valor, então altere essa linha para `obteve, _ := Corredor(urlLenta, urlRapida)`. Sabendo disso devemos verificar se _não_ obteremos um erro em nosso caso de sucesso.
+O compilador vai reclamar sobre seu _primeiro teste_ esperar apenas um valor, então altere essa linha para `obteve, _ := Corredor(URLLenta, URLRapida)`. Sabendo disso devemos verificar se _não_ obteremos um erro em nosso caso de sucesso.
 
 Se executar isso agora, o teste irá falhar após 11 segundos.
 


### PR DESCRIPTION
As variáveis **URLLenta**, **urlRapida** aparacem com grafias diferentes ao longo do texto e código. Alterei para que se mantivessem com a mesma grafia.

![image](https://github.com/larien/aprenda-go-com-testes/assets/97068163/6a999b2c-c1ef-4ca1-a082-a2f1f957ee89)
